### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   validate-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/radicand/printable-banners/security/code-scanning/5](https://github.com/radicand/printable-banners/security/code-scanning/5)

To fix the issue, add a `permissions` key at the root level of the workflow to explicitly define the least privileges required for the jobs. Based on the current workflow, the minimal permissions required are `contents: read`, as the workflow reads repository contents but does not modify them. Adding this block ensures the GITHUB_TOKEN has restricted access, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
